### PR TITLE
Fix a typo in lab 3 on the mongodb properties file name

### DIFF
--- a/docs/lab-3/README.md
+++ b/docs/lab-3/README.md
@@ -92,7 +92,7 @@ connection-password=presto
 ```
 
 
-For the MongoDB, you can find the following content in the `./catalog-new/mongo.properties` file. It contains
+For the MongoDB, you can find the following content in the `./catalog-new/mongodb.properties` file. It contains
 the information about the MongoDB you set up earlier:
 
 ```


### PR DESCRIPTION
In Lab 3, it says:

	For the MongoDB, you can find the following content in the ./catalog-new/mongo.properties file.

However, during the workshop, at this step, found **mongodb**.properties instead of **mongo**.properties
```
	presto@prestoworkshop-vm-12:~/presto-101-lab$ ls catalog
	jmx.properties  memory.properties  mongodb.properties  mysql.properties  tpcds.properties  tpch.properties
```